### PR TITLE
学术评语和答辩决议书的目录及页面更新

### DIFF
--- a/master_pang.tex
+++ b/master_pang.tex
@@ -197,10 +197,23 @@
 \fancyfoot[C]{\songti\zihao{5}{\thepage}}
 \input{chapter/myPapers.tex}
 
-\end{document}
-
-% 源代码地址：https://github.com/Ftine/SZU_Latex_Master_Template
+% 添加学术评语目录条目
+%\addtocontents{toc}{\protect\vspace{1.6pt}}
+%\addtocontents{toc}{\noindent\protect\fontspec{songti-Bold.otf}\protect\zihao{-4}\protect\normalfont 附：指导教师对研究生学位论文的学术评语\par}
+% 添加答辩决议书目录条目
+%\addtocontents{toc}{\protect\vspace{1.6pt}}
+%\addtocontents{toc}{\noindent\protect\fontspec{songti-Bold.otf}\protect\zihao{-4}\protect\normalfont ~~~~~~~~答辩委员会决议书\par}
+% 添加学术评语页面
+%\clearpage
+%\includepdf[pages={1}]{chapter/comment.pdf}
+% 添加答辩决议书页面
+%\clearpage
+%\includepdf[pages={1,2}]{chapter/decision.pdf}
 
 %当需要在论文末尾插入相关的文件，可以生成pdf文件格式进行附加，附加一页就是1，多页就是1，2，3
 %\includepdf[pages={1}]{chapter/comment.pdf}
 %\includepdf[pages={1}]{chapter/decision.pdf}
+
+\end{document}
+
+% 源代码地址：https://github.com/Ftine/SZU_Latex_Master_Template


### PR DESCRIPTION
答辩完成后，要在学位论文最终版最后提交指导老师的学术评语和答辩决议书，共两份文件三页。

原来的版本把添加文件的代码写在 end document之后。我将它提前到end document之前，并且增加了在目录上也显示出对应条目的代码，符合学校学位论文要求。
答辩决议书是两页，我把默认的代码的页码从1改成1,2。

我提交的代码默认是注释状态的，等到需要添加后将其取消注释，对应的pdf文件上传到chapter目录下就可以使用。