### PR TITLE
英文摘要格式设置

### DIFF
--- a/chapter/abstract.tex
+++ b/chapter/abstract.tex
@@ -16,13 +16,17 @@
 xx分析；xx学习
 \end{keywordCN}
 
+\fancyhead[C]{\zihao{5}\songti Your English Title}
+\pagestyle{fancy}
 \begin{abstractEN}
 \setlength{\baselineskip}{23pt} %设置行距23磅
+
 Graduate life is a journey filled with wisdom and exploration. During this stage, students delve into more profound academic content, face more challenging problems, and embark on independent research within the academic community. The academic atmosphere in graduate school provides students with opportunities to deeply explore their areas of interest, engaging in discussions and solving complex problems collaboratively with mentors and peers.
 
 Beyond academic challenges, graduate life encompasses a broader spectrum of social and professional development. Students learn from and connect with peers from diverse backgrounds and fields, fostering profound interpersonal relationships. Simultaneously, interactions and collaborations with mentors open up broader opportunities for professional development, aiding students in shaping their future careers more effectively.
 
 In graduate school, students have the chance to participate in various academic and social activities, broadening their horizons. This includes academic seminars, special lectures, collaborative research projects, and more. Through these activities, they gain a comprehensive understanding of their respective fields and establish connections with other researchers.
+
 \end{abstractEN}
 
 \begin{keywordEN}


### PR DESCRIPTION
添加了英文摘要页面的页眉（记得改自己的论文标题上去）
英文摘要的end环节前面最好加一行空行，否则跨页的话可能会导致最后一段英文摘要的行间距比前几段更小。

具体原理不明，总之我这么解决了。