### PR TITLE
解决英文摘要跨页最后一段行间距偏小问题

### DIFF
--- a/chapter/abstract.tex
+++ b/chapter/abstract.tex
@@ -16,8 +16,6 @@
 xx分析；xx学习
 \end{keywordCN}
 
-\fancyhead[C]{\zihao{5}\songti Your English Title}
-\pagestyle{fancy}
 \begin{abstractEN}
 \setlength{\baselineskip}{23pt} %设置行距23磅
 


### PR DESCRIPTION
在\begin{abstractEN}后和\end{abstractEN}前都加一个空行，于英文摘要文本隔开，可以避免出现这个bug。原因不明。