### PR TITLE
Fix:修复了缩略语与目录的顺序错误

### DIFF
--- a/chapter/abstract.tex
+++ b/chapter/abstract.tex
@@ -31,20 +31,3 @@ In graduate school, students have the chance to participate in various academic 
 xx Analysis; xx Learning
 \end{keywordEN}
 
-
-
-\begin{signAndABC}
-
-\begin{adjustwidth}{-\leftskip}{0pt}
- % 调整表格宽度
-\renewcommand\arraystretch{1.5}
-\begin{tabular}{l@{\hspace{4em}}l}
-VAE & 变分自编码器（Variational Auto-Encoder） \\
-CNN & 卷积神经网络（Convolutional Neural Network） \\
-\end{tabular}
-\end{adjustwidth}
-
-
-\end{signAndABC}
-
-

--- a/chapter/sign_and_ABC.tex
+++ b/chapter/sign_and_ABC.tex
@@ -1,0 +1,25 @@
+\begin{signAndABC}
+
+\begin{adjustwidth}{-\leftskip}{0pt}
+    % 调整表格宽度
+\renewcommand\arraystretch{1.5}
+\begin{tabular}{l@{\hspace{4em}}l}
+VAE & 变分自编码器（Variational Auto-Encoder） \\
+CNN & 卷积神经网络（Convolutional Neural Network）
+\end{tabular}
+\end{adjustwidth}
+
+\end{signAndABC}
+
+%此处为原cls文件中有关后续正文页面的页眉页脚设置
+\newpage
+\pagenumbering{arabic}
+\pagestyle{fancy} % 页眉横线样式
+\fancyhead{}
+
+\fancyhead[C]{\songti\zihao{5}{\titleCN}}
+% 全局页眉 设置为章节标题
+\fancyhead[C]{\songti\zihao{5}\nouppercase\leftmark}
+%全局页号设置
+\fancyfoot[C]{\songti\zihao{5}{\thepage}}
+\setcounter{page}{1}

--- a/master_pang.tex
+++ b/master_pang.tex
@@ -123,13 +123,14 @@
 \fancyhead[C]{\songti\zihao{5}{\titleCN}}
 \fancyhead[C]{\songti\zihao{5}{\titleEN}}
 	
-%中英文摘要 以及 缩写表
+%中英文摘要
 \input{chapter/abstract.tex} 
 	
 \setlength{\baselineskip}{23pt} %设置行距23磅
 	
 \tableofcontents	%目录
-	
+%缩略语及后续正文页眉页脚设置
+\input{chapter/sign_and_ABC.tex}
 %%%%%%%%% 图索引和表索引
 % \renewcommand\listfigurename{\songti\zihao{2}{\textbf{图~~目~~录}}}
 % \renewcommand\listtablename{\songti\zihao{2}{\textbf{表~~目~~录}}}

--- a/szu-master.cls
+++ b/szu-master.cls
@@ -78,18 +78,8 @@
 %//相关设置
 \renewcommand{\tableofcontents}{%
 	\pagestyle{plain}
-	\savedtableofcontents
-	\newpage
-	\pagenumbering{arabic}
-	\pagestyle{fancy} % 页眉横线样式
-	\fancyhead{}
- 
-    \fancyhead[C]{\songti\zihao{5}{\titleCN}}
-% 全局页眉 设置为章节标题
-\fancyhead[C]{\songti\zihao{5}\nouppercase\leftmark}
-%全局页号设置
-\fancyfoot[C]{\songti\zihao{5}{\thepage}}
-\setcounter{page}{1}
+	\savedtableofcontents	
+	%将有关正文页面的设置移到缩略语插入后
 }
 
 %参考文献样式


### PR DESCRIPTION
发现缩略语的位置放置在了目录之前，根据要求应放置在目录后
主要修改：
1、将缩略语部分从abstract.tex文件中独立出来，成为一个新文件sign_and_ABC.tex；
2、将 szu-master.cls文件中 目录部分 有关后续正文页眉页脚的额外部分 移动到新文件sign_and_ABC.tex中 缩略语插入后；
3、同时对应在主文件中添加了插入sign_and_ABC.tex页面的语句

