### PR TITLE
添加 pifont 宏包支持带圈数字

### DIFF
--- a/master_pang.tex
+++ b/master_pang.tex
@@ -38,6 +38,7 @@
 \usepackage{epsfig,bm}
 \usepackage{slashbox}
 \usepackage{enumitem}
+\usepackage{pifont} % 带圈数字 \ding{172}=① \ding{173}=② 等
 \usepackage{amssymb,amsthm,amssymb}
 \usepackage{graphicx,subfigure}
 \usepackage{graphicx}


### PR DESCRIPTION
引入pifont包实现带圈数字
`ding{172}=① ding{173}=②`
<img width="818" height="368" alt="image" src="https://github.com/user-attachments/assets/4478b742-ee68-44e8-9246-0333375ec92d" />
