### PR TITLE
添加参考文献的中文用例，符合学校规定的要求，中文参考文献不再显示英文的et al

### DIFF
--- a/ref_paper.bib
+++ b/ref_paper.bib
@@ -9,6 +9,17 @@
   publisher={北京: 机械工业出版社},
   language={zh}
 }
+#添加真实用例，以说明增加language={zh}字段的核心作用
+@article{孙志军2012深度学习研究综述,
+  title={深度学习研究综述},
+  author={孙志军 and 薛磊 and 许阳明 and 王正},
+  journal={计算机应用研究},
+  volume={29},
+  number={8},
+  pages={2806--2810},
+  year={2012},
+  language={zh}
+}
 
 @article{atamuradov2017prognostics,
   title={Prognostics and health management for maintenance practitioners-Review, implementation and tools evaluation.},


### PR DESCRIPTION
响应之前 Issue 中的讨论，我已更新了 `ref_paper.bib` 文件。

具体修改：
在 `@book{cryer2011}` 条目中增加了 `language={zh}` 字段。提供了一个真实的示例，展示如何正确显示中文参考文献中“等” (而非 et al) 的要求，符合学校规范。

Fixes #23